### PR TITLE
Early upgrade trial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/centos-base:26b3cc460ee5ba775702eeaa11bf24464adc822c
+FROM quay.io/ukhomeofficedigital/centos-base
 
 USER root
 
@@ -23,7 +23,7 @@ RUN yum clean all && \
 
 VOLUME ["/data/db","/data/configdb"]
 
-RUN pip install pymongo[tls]==3.6.1
+RUN pip2 install pymongo[tls]==3.11.3
 
 USER ${UID}
 

--- a/mongodb-org.repo
+++ b/mongodb-org.repo
@@ -1,6 +1,6 @@
-[mongodb-org-3.6]
+[mongodb-org-4.0]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.6/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/4.0/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-3.6.asc
+gpgkey=https://www.mongodb.org/static/pgp/server-4.0.asc

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -8,7 +8,7 @@ set -e
 ##### PKI #####
 
 # CA bundle
-export MONGODB_SSL_CA="${MONGODB_SSL_CA:-/etc/ssl/certs/ca-certificates.crt}"
+export MONGODB_SSL_CA="${MONGODB_SSL_CA:-/etc/ssl/certs/ca-bundle.crt}"
 
 # Server key / certificate
 export MONGODB_SSL_CERT="${MONGODB_SSL_CERT:-/mnt/certs/tls.pem}"

--- a/scripts/mongoconf
+++ b/scripts/mongoconf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 ########## MODULES ##########
 


### PR DESCRIPTION
Centos 7 -> Centos 8
Mongo 3.6 -> Mongo 4.0

Appears to have the same logging output when using `docker build -t xxx .; docker run xxx ` as previous versions, so looks healthy at least.. Perhaps worth considering?